### PR TITLE
Release 103

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "projectmanager-sdk",
-    "version": "102.0.2886",
+    "version": "103.0.3003",
     "description": "Software development kit for the ProjectManager.com API. for TypeScript",
     "repository": "https://github.com/projectmgr/projectmanager-sdk-typescript",
     "license": "MIT",

--- a/src/ProjectManagerClient.ts
+++ b/src/ProjectManagerClient.ts
@@ -8,7 +8,7 @@
  *
  * @author     ProjectManager.com <support@projectmanager.com>
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    102.0.2886
+ * @version    103.0.3003
  * @link       https://github.com/projectmgr/projectmanager-sdk-typescript
  */
 
@@ -78,7 +78,7 @@ export class ProjectManagerClient {
 
   // The URL of the environment we will use
   private readonly serverUrl: string;
-  private readonly version: string = "102.0.2886";
+  private readonly version: string = "103.0.3003";
   private bearerToken: string | null = null;
   private sdkName = "TypeScript";
   private appName: string | null = null;

--- a/src/clients/ChangesetClient.ts
+++ b/src/clients/ChangesetClient.ts
@@ -14,6 +14,7 @@
 import { ProjectManagerClient } from "../index.js";
 import { AstroResult } from "../index.js";
 import { ChangesetGetResponseDto } from "../index.js";
+import { ChangeSetResponseDto } from "../index.js";
 
 export class ChangesetClient {
   private readonly client: ProjectManagerClient;
@@ -53,5 +54,25 @@ export class ChangesetClient {
   retrieveCompletedChangeset(changeSetId: string): Promise<AstroResult<ChangesetGetResponseDto>> {
     const url = `/api/data/changesets/${changeSetId}/poll`;
     return this.client.request<AstroResult<ChangesetGetResponseDto>>("get", url, null, null);
+  }
+
+  /**
+   * Retrieve Changesets by Project ID
+   *
+   * @param projectId Documentation pending
+   * @param version Documentation pending
+   * @param page Documentation pending
+   * @param take Documentation pending
+   */
+  retrieveChangesetsbyprojectID(projectId: string, version?: number, page?: number, take?: number): Promise<AstroResult<ChangeSetResponseDto[]>> {
+    const url = `/api/data/projects/${projectId}/changesets`;
+    const options = {
+      params: {
+        'version': version,
+        'page': page,
+        'take': take,
+      },
+    };
+    return this.client.request<AstroResult<ChangeSetResponseDto[]>>("get", url, options, null);
   }
 }

--- a/src/clients/ProjectClient.ts
+++ b/src/clients/ProjectClient.ts
@@ -90,4 +90,22 @@ export class ProjectClient {
     const url = `/api/data/projects/${projectId}`;
     return this.client.request<AstroResult<object>>("put", url, null, body);
   }
+
+  /**
+   * Delete a project based on the details provided.
+   *
+   * A Project is a collection of Tasks that contributes towards a goal.  Within a Project, Tasks represent individual items of work that team members must complete.  The sum total of Tasks within a Project represents the work to be completed for that Project.
+   *
+   * @param projectId The unique identifier of the Project to delete
+   * @param hardDelete Hard delete project true or false
+   */
+  deleteProject(projectId: string, hardDelete?: boolean): Promise<AstroResult<object>> {
+    const url = `/api/data/projects/${projectId}`;
+    const options = {
+      params: {
+        'hardDelete': hardDelete,
+      },
+    };
+    return this.client.request<AstroResult<object>>("delete", url, options, null);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    102.0.2886
+ * @version    103.0.3003
  * @link       https://github.com/projectmgr/projectmanager-sdk-typescript
  */
 
@@ -62,6 +62,7 @@ export { AstroResult } from "./models/AstroResult.js";
 export { AuthenticationDto } from "./models/AuthenticationDto.js";
 export { AuthenticationStatusDto } from "./models/AuthenticationStatusDto.js";
 export { ChangesetGetResponseDto } from "./models/ChangesetGetResponseDto.js";
+export { ChangeSetResponseDto } from "./models/ChangeSetResponseDto.js";
 export { ChangeSetStatusDto } from "./models/ChangeSetStatusDto.js";
 export { ConnectionSchemaDto } from "./models/ConnectionSchemaDto.js";
 export { CountryHolidayDto } from "./models/CountryHolidayDto.js";
@@ -100,6 +101,7 @@ export { ProjectCustomerDto } from "./models/ProjectCustomerDto.js";
 export { ProjectDto } from "./models/ProjectDto.js";
 export { ProjectFieldValueDto } from "./models/ProjectFieldValueDto.js";
 export { ProjectFileDto } from "./models/ProjectFileDto.js";
+export { ProjectFileFolderDto } from "./models/ProjectFileFolderDto.js";
 export { ProjectFileTaskDto } from "./models/ProjectFileTaskDto.js";
 export { ProjectFolderDto } from "./models/ProjectFolderDto.js";
 export { ProjectManagerDto } from "./models/ProjectManagerDto.js";

--- a/src/models/ChangeSetResponseDto.ts
+++ b/src/models/ChangeSetResponseDto.ts
@@ -1,0 +1,99 @@
+/**
+ * ProjectManager API for TypeScript
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-typescript
+ */
+
+
+/**
+ * The project task change set
+ */
+export type ChangeSetResponseDto = {
+
+  /**
+   * Project Changeset ID
+   */
+  projectChangeSetId: number;
+
+  /**
+   * The unique identifier of this Changeset
+   */
+  id: string;
+
+  /**
+   * Project ID
+   */
+  projectId: string;
+
+  /**
+   * Task version
+   */
+  version: number | null;
+
+  /**
+   * Created by GUID
+   */
+  createBy: string;
+
+  /**
+   * Created date
+   */
+  createDate: string;
+
+  /**
+   * Change set action
+   */
+  actions: string | null;
+
+  /**
+   * Change set in json string
+   */
+  changeSets: string | null;
+
+  /**
+   * Processed date
+   */
+  processDate: string | null;
+
+  /**
+   * If process was successful
+   */
+  success: boolean | null;
+
+  /**
+   * Error message
+   */
+  exception: string | null;
+
+  /**
+   * UI ID
+   */
+  clientId: string | null;
+
+  /**
+   * Changeset JSON data
+   */
+  jsonData: string | null;
+
+  /**
+   * Is change set from UNDO
+   */
+  isUndo: boolean;
+
+  /**
+   * The state of the changeset
+   */
+  state: number;
+
+  /**
+   * Business ID
+   */
+  businessId: string;
+};

--- a/src/models/ProjectFileDto.ts
+++ b/src/models/ProjectFileDto.ts
@@ -12,6 +12,7 @@
  */
 
 import { ProjectFileTaskDto } from "../index.js";
+import { ProjectFileFolderDto } from "../index.js";
 
 export type ProjectFileDto = {
 
@@ -38,4 +39,13 @@ export type ProjectFileDto = {
    * To expand this field, specify the name of this field in the `$expand` parameter.
    */
   task: ProjectFileTaskDto | null;
+
+  /**
+   * The folder that this file relates to.
+   *
+   * This field will be present when you fetch a single object.
+   * When you query for multiple objects, this field is not included in results by default.
+   * To expand this field, specify the name of this field in the `$expand` parameter.
+   */
+  folder: ProjectFileFolderDto | null;
 };

--- a/src/models/ProjectFileFolderDto.ts
+++ b/src/models/ProjectFileFolderDto.ts
@@ -1,0 +1,29 @@
+/**
+ * ProjectManager API for TypeScript
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-typescript
+ */
+
+
+/**
+ * A Folder is a named storage location that can contain Files.
+ */
+export type ProjectFileFolderDto = {
+
+  /**
+   * The unique identifier of this Folder.
+   */
+  id: string;
+
+  /**
+   * The name of this Folder.
+   */
+  name: string | null;
+};

--- a/src/models/WorkSpaceDto.ts
+++ b/src/models/WorkSpaceDto.ts
@@ -66,11 +66,6 @@ export type WorkSpaceDto = {
   registerDate: string;
 
   /**
-   * True if the user has accepted an invitation to this Workspace.
-   */
-  isInviteAccepted: boolean;
-
-  /**
    * The unique identifier of the BusinessUser that is the owner of this Workspace.
    */
   businessUserId: string | null;


### PR DESCRIPTION
# Patch notes for 103.0.3003

These patch notes summarize the changes from version 102.0.2886.

Added 2 new APIs:
* Changeset.RetrieveChangesetsByProjectID (GET /api/data/projects/{projectId}/changesets)
* Project.DeleteProject (DELETE /api/data/projects/{projectId})

Deprecated 1 old APIs:
* TaskMetadata.GetTaskMetadata
