### PR TITLE
Release 119

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "projectmanager-sdk",
-    "version": "117.0.4438",
+    "version": "119.0.4625",
     "description": "Software development kit for the ProjectManager.com API. for TypeScript",
     "repository": "https://github.com/projectmgr/projectmanager-sdk-typescript",
     "license": "MIT",

--- a/src/ProjectManagerClient.ts
+++ b/src/ProjectManagerClient.ts
@@ -8,7 +8,7 @@
  *
  * @author     ProjectManager.com <support@projectmanager.com>
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    117.0.4438
+ * @version    119.0.4625
  * @link       https://github.com/projectmgr/projectmanager-sdk-typescript
  */
 
@@ -19,15 +19,15 @@ import { DiscussionClient } from "./index.js";
 import { FileClient } from "./index.js";
 import { HolidayClient } from "./index.js";
 import { HomeFileClient } from "./index.js";
-import { IntegrationClient } from "./index.js";
 import { IntegrationCategoryClient } from "./index.js";
+import { IntegrationClient } from "./index.js";
 import { IntegrationProviderClient } from "./index.js";
 import { LicenseClient } from "./index.js";
 import { MeClient } from "./index.js";
 import { NotificationClient } from "./index.js";
 import { NptFilesClient } from "./index.js";
-import { ProjectClient } from "./index.js";
 import { ProjectChargeCodeClient } from "./index.js";
+import { ProjectClient } from "./index.js";
 import { ProjectCustomerClient } from "./index.js";
 import { ProjectFieldClient } from "./index.js";
 import { ProjectFileClient } from "./index.js";
@@ -36,12 +36,14 @@ import { ProjectMembersClient } from "./index.js";
 import { ProjectPriorityClient } from "./index.js";
 import { ProjectStatusClient } from "./index.js";
 import { ProjectTemplateClient } from "./index.js";
+import { ProjectVersionClient } from "./index.js";
 import { ResourceClient } from "./index.js";
 import { ResourceSkillClient } from "./index.js";
 import { ResourceTeamClient } from "./index.js";
+import { RiskClient } from "./index.js";
 import { TagClient } from "./index.js";
-import { TaskClient } from "./index.js";
 import { TaskAssigneeClient } from "./index.js";
+import { TaskClient } from "./index.js";
 import { TaskFieldClient } from "./index.js";
 import { TaskFileClient } from "./index.js";
 import { TaskMetadataClient } from "./index.js";
@@ -79,7 +81,7 @@ export class ProjectManagerClient {
 
   // The URL of the environment we will use
   private readonly serverUrl: string;
-  private readonly version: string = "117.0.4438";
+  private readonly version: string = "119.0.4625";
   private bearerToken: string | null = null;
   private sdkName = "TypeScript";
   private appName: string | null = null;
@@ -92,15 +94,15 @@ export class ProjectManagerClient {
   public readonly File: FileClient;
   public readonly Holiday: HolidayClient;
   public readonly HomeFile: HomeFileClient;
-  public readonly Integration: IntegrationClient;
   public readonly IntegrationCategory: IntegrationCategoryClient;
+  public readonly Integration: IntegrationClient;
   public readonly IntegrationProvider: IntegrationProviderClient;
   public readonly License: LicenseClient;
   public readonly Me: MeClient;
   public readonly Notification: NotificationClient;
   public readonly NptFiles: NptFilesClient;
-  public readonly Project: ProjectClient;
   public readonly ProjectChargeCode: ProjectChargeCodeClient;
+  public readonly Project: ProjectClient;
   public readonly ProjectCustomer: ProjectCustomerClient;
   public readonly ProjectField: ProjectFieldClient;
   public readonly ProjectFile: ProjectFileClient;
@@ -109,12 +111,14 @@ export class ProjectManagerClient {
   public readonly ProjectPriority: ProjectPriorityClient;
   public readonly ProjectStatus: ProjectStatusClient;
   public readonly ProjectTemplate: ProjectTemplateClient;
+  public readonly ProjectVersion: ProjectVersionClient;
   public readonly Resource: ResourceClient;
   public readonly ResourceSkill: ResourceSkillClient;
   public readonly ResourceTeam: ResourceTeamClient;
+  public readonly Risk: RiskClient;
   public readonly Tag: TagClient;
-  public readonly Task: TaskClient;
   public readonly TaskAssignee: TaskAssigneeClient;
+  public readonly Task: TaskClient;
   public readonly TaskField: TaskFieldClient;
   public readonly TaskFile: TaskFileClient;
   public readonly TaskMetadata: TaskMetadataClient;
@@ -138,15 +142,15 @@ export class ProjectManagerClient {
     this.File = new FileClient(this);
     this.Holiday = new HolidayClient(this);
     this.HomeFile = new HomeFileClient(this);
-    this.Integration = new IntegrationClient(this);
     this.IntegrationCategory = new IntegrationCategoryClient(this);
+    this.Integration = new IntegrationClient(this);
     this.IntegrationProvider = new IntegrationProviderClient(this);
     this.License = new LicenseClient(this);
     this.Me = new MeClient(this);
     this.Notification = new NotificationClient(this);
     this.NptFiles = new NptFilesClient(this);
-    this.Project = new ProjectClient(this);
     this.ProjectChargeCode = new ProjectChargeCodeClient(this);
+    this.Project = new ProjectClient(this);
     this.ProjectCustomer = new ProjectCustomerClient(this);
     this.ProjectField = new ProjectFieldClient(this);
     this.ProjectFile = new ProjectFileClient(this);
@@ -155,12 +159,14 @@ export class ProjectManagerClient {
     this.ProjectPriority = new ProjectPriorityClient(this);
     this.ProjectStatus = new ProjectStatusClient(this);
     this.ProjectTemplate = new ProjectTemplateClient(this);
+    this.ProjectVersion = new ProjectVersionClient(this);
     this.Resource = new ResourceClient(this);
     this.ResourceSkill = new ResourceSkillClient(this);
     this.ResourceTeam = new ResourceTeamClient(this);
+    this.Risk = new RiskClient(this);
     this.Tag = new TagClient(this);
-    this.Task = new TaskClient(this);
     this.TaskAssignee = new TaskAssigneeClient(this);
+    this.Task = new TaskClient(this);
     this.TaskField = new TaskFieldClient(this);
     this.TaskFile = new TaskFileClient(this);
     this.TaskMetadata = new TaskMetadataClient(this);

--- a/src/clients/NotificationClient.ts
+++ b/src/clients/NotificationClient.ts
@@ -96,7 +96,7 @@ export class NotificationClient {
    * workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
    * than 1,000 pending notifications some old notifications will be deleted automatically.
    *
-   * @param id Documentation pending
+   * @param id The unique identifier of the notification to mark read
    */
   markNotificationRead(id: string): Promise<AstroResult<NotificationTimestampDto>> {
     const url = `/api/data/notifications/${id}/markread`;
@@ -123,7 +123,7 @@ export class NotificationClient {
    * workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
    * than 1,000 pending notifications some old notifications will be deleted automatically.
    *
-   * @param id Documentation pending
+   * @param id The unique identifier of the notification to mark read
    */
   deleteNotification(id: string): Promise<AstroResult<object>> {
     const url = `/api/data/notifications/delete/${id}`;
@@ -137,7 +137,7 @@ export class NotificationClient {
    * workspace. Notifications are ephemeral and may be deleted when they are no longer needed.  When a user has more
    * than 1,000 pending notifications some old notifications will be deleted automatically.
    *
-   * @param id Documentation pending
+   * @param id The unique identifier of the notification to mark read
    */
   markNotificationUnread(id: string): Promise<AstroResult<object>> {
     const url = `/api/data/notifications/${id}/markunread`;

--- a/src/clients/ProjectVersionClient.ts
+++ b/src/clients/ProjectVersionClient.ts
@@ -1,0 +1,78 @@
+/**
+ * ProjectManager API for TypeScript
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-typescript
+ */
+
+import { ProjectManagerClient } from "../index.js";
+import { AstroResult } from "../index.js";
+import { ProjectVersionDto } from "../index.js";
+
+export class ProjectVersionClient {
+  private readonly client: ProjectManagerClient;
+
+  /**
+   * Internal constructor for this client library
+   */
+  public constructor(client: ProjectManagerClient) {
+    this.client = client;
+  }
+
+  /**
+   * Returns projects versions including version, user who made changes
+   *
+   * @param projectId The unique identifier of the Project
+   */
+  retrieveProjectVersions(projectId: string): Promise<AstroResult<ProjectVersionDto[]>> {
+    const url = `/api/data/projects/${projectId}/versions`;
+    return this.client.request<AstroResult<ProjectVersionDto[]>>("get", url, null, null);
+  }
+
+  /**
+   * Exports and returns project version as an MS Project XML attachment
+   *
+   * @param projectChangeId Project change Guid
+   */
+  downloadMSProjectXml(projectChangeId: string): Promise<AstroResult<Blob>> {
+    const url = `/api/data/projects/${projectChangeId}/version/download`;
+    return this.client.requestBlob("get", url, null, null);
+  }
+
+  /**
+   * Restores a Project to the state it was in at a specific Version in time.
+   *
+   * If successful, all changes made to the Project since this Version will be undone and the Project will
+   * return to its former state.
+   *
+   * @param projectId The unique identifier of the Project to restore
+   * @param version The version number to restore to
+   */
+  restoreProjectVersion(projectId: string, version: number): Promise<AstroResult<object>> {
+    const url = `/api/data/projects/${projectId}/version/${version}/restore`;
+    return this.client.request<AstroResult<object>>("post", url, null, null);
+  }
+
+  /**
+   * Create a Copy of a Project as of a specific Version, optionally moving it to a new Timezone.
+   *
+   * @param projectId The unique identifier of the Project to copy
+   * @param version The version number of the Project to copy
+   * @param timezoneOffset If specified, sets the default timezone of the newly copied Project to this specified timezone
+   */
+  copyProjectVersion(projectId: string, version: number, timezoneOffset?: number): Promise<AstroResult<object>> {
+    const url = `/api/data/projects/${projectId}/version/${version}/copy`;
+    const options = {
+      params: {
+        'timezoneOffset': timezoneOffset,
+      },
+    };
+    return this.client.request<AstroResult<object>>("post", url, options, null);
+  }
+}

--- a/src/clients/RiskClient.ts
+++ b/src/clients/RiskClient.ts
@@ -1,0 +1,41 @@
+/**
+ * ProjectManager API for TypeScript
+ *
+ * (c) 2023-2024 ProjectManager.com, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author     ProjectManager.com <support@projectmanager.com>
+ * @copyright  2023-2024 ProjectManager.com, Inc.
+ * @link       https://github.com/projectmgr/projectmanager-sdk-typescript
+ */
+
+import { ProjectManagerClient } from "../index.js";
+import { AstroResult } from "../index.js";
+import { ExportDto } from "../index.js";
+import { RiskExportSettingsDto } from "../index.js";
+
+export class RiskClient {
+  private readonly client: ProjectManagerClient;
+
+  /**
+   * Internal constructor for this client library
+   */
+  public constructor(client: ProjectManagerClient) {
+    this.client = client;
+  }
+
+  /**
+   * Initiates a new Export action for Risks.
+   *
+   * Returns the identifier of this Risk Export.
+   *
+   * @param projectId The unique identifier of the Project for which to export Risks
+   * @param body The settings to use for this export action
+   */
+  createRiskExport(projectId: string, body: RiskExportSettingsDto): Promise<AstroResult<ExportDto>> {
+    const url = `/api/data/projects/${projectId}/risks/export`;
+    return this.client.request<AstroResult<ExportDto>>("post", url, null, body);
+  }
+}

--- a/src/clients/TaskMetadataClient.ts
+++ b/src/clients/TaskMetadataClient.ts
@@ -46,12 +46,13 @@ export class TaskMetadataClient {
   }
 
   /**
+   * Get tasks by project ID and foreign key ID
    *
    * @param foreignKey Foreign Key ID
    * @param projectId Project ID
    * @param isSystem If metadata is for system or customer, isSystem = true is only of ProjectManager
    */
-  gettasksbyprojectIDandforeignkeyID(projectId: string, foreignKey?: string, isSystem?: boolean): Promise<AstroResult<TaskMetadataSearchDto[]>> {
+  taskMetadataSearch(projectId: string, foreignKey?: string, isSystem?: boolean): Promise<AstroResult<TaskMetadataSearchDto[]>> {
     const url = `/api/data/projects/${projectId}/tasks/metadata`;
     const options = {
       params: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  * @author     ProjectManager.com <support@projectmanager.com>
  *             
  * @copyright  2023-2024 ProjectManager.com, Inc.
- * @version    117.0.4438
+ * @version    119.0.4625
  * @link       https://github.com/projectmgr/projectmanager-sdk-typescript
  */
 
@@ -22,15 +22,15 @@ export { DiscussionClient } from "./clients/DiscussionClient.js";
 export { FileClient } from "./clients/FileClient.js";
 export { HolidayClient } from "./clients/HolidayClient.js";
 export { HomeFileClient } from "./clients/HomeFileClient.js";
-export { IntegrationClient } from "./clients/IntegrationClient.js";
 export { IntegrationCategoryClient } from "./clients/IntegrationCategoryClient.js";
+export { IntegrationClient } from "./clients/IntegrationClient.js";
 export { IntegrationProviderClient } from "./clients/IntegrationProviderClient.js";
 export { LicenseClient } from "./clients/LicenseClient.js";
 export { MeClient } from "./clients/MeClient.js";
 export { NotificationClient } from "./clients/NotificationClient.js";
 export { NptFilesClient } from "./clients/NptFilesClient.js";
-export { ProjectClient } from "./clients/ProjectClient.js";
 export { ProjectChargeCodeClient } from "./clients/ProjectChargeCodeClient.js";
+export { ProjectClient } from "./clients/ProjectClient.js";
 export { ProjectCustomerClient } from "./clients/ProjectCustomerClient.js";
 export { ProjectFieldClient } from "./clients/ProjectFieldClient.js";
 export { ProjectFileClient } from "./clients/ProjectFileClient.js";
@@ -39,12 +39,14 @@ export { ProjectMembersClient } from "./clients/ProjectMembersClient.js";
 export { ProjectPriorityClient } from "./clients/ProjectPriorityClient.js";
 export { ProjectStatusClient } from "./clients/ProjectStatusClient.js";
 export { ProjectTemplateClient } from "./clients/ProjectTemplateClient.js";
+export { ProjectVersionClient } from "./clients/ProjectVersionClient.js";
 export { ResourceClient } from "./clients/ResourceClient.js";
 export { ResourceSkillClient } from "./clients/ResourceSkillClient.js";
 export { ResourceTeamClient } from "./clients/ResourceTeamClient.js";
+export { RiskClient } from "./clients/RiskClient.js";
 export { TagClient } from "./clients/TagClient.js";
-export { TaskClient } from "./clients/TaskClient.js";
 export { TaskAssigneeClient } from "./clients/TaskAssigneeClient.js";
+export { TaskClient } from "./clients/TaskClient.js";
 export { TaskFieldClient } from "./clients/TaskFieldClient.js";
 export { TaskFileClient } from "./clients/TaskFileClient.js";
 export { TaskMetadataClient } from "./clients/TaskMetadataClient.js";

--- a/src/models/DiscussionCommentFileDto.ts
+++ b/src/models/DiscussionCommentFileDto.ts
@@ -12,6 +12,10 @@
  */
 
 
+/**
+ * The DiscussionCommentFile represents a file that has been attached to a discussion
+ * and is available for download.
+ */
 export type DiscussionCommentFileDto = {
 
   /**
@@ -25,7 +29,7 @@ export type DiscussionCommentFileDto = {
   name: string | null;
 
   /**
-   * The url of the file which can be used for downloading
+   * The url of the DownloadFile API to retrieve this file
    */
   url: string | null;
 };

--- a/src/models/NotificationDataDto.ts
+++ b/src/models/NotificationDataDto.ts
@@ -42,6 +42,9 @@ export type NotificationDataDto = {
    */
   projectName: string | null;
 
+  /**
+   * Name of the task this notification is related to
+   */
   taskName: string | null;
 
   /**

--- a/src/models/ProjectFileDto.ts
+++ b/src/models/ProjectFileDto.ts
@@ -14,6 +14,10 @@
 import { ProjectFileTaskDto } from "../index.js";
 import { ProjectFileFolderDto } from "../index.js";
 
+/**
+ * The ProjectFile represents an attached file that is connected to a Project
+ * and can be retrieved for download.
+ */
 export type ProjectFileDto = {
 
   /**

--- a/src/models/ProjectFileTaskDto.ts
+++ b/src/models/ProjectFileTaskDto.ts
@@ -12,6 +12,9 @@
  */
 
 
+/**
+ * Represents information about a Task that is relevant to a ProjectFile
+ */
 export type ProjectFileTaskDto = {
 
   /**

--- a/src/models/ProjectVersionChangeDataDto.ts
+++ b/src/models/ProjectVersionChangeDataDto.ts
@@ -12,15 +12,35 @@
  */
 
 
+/**
+ * A ProjectVersionChangeData is information about a change made to a Project that took
+ * it from one Version to another.  The information in this object can help track the
+ * details of changes made by the user.
+ */
 export type ProjectVersionChangeDataDto = {
 
+  /**
+   * The type of change made
+   */
   type: string | null;
 
+  /**
+   * The method used to make the change
+   */
   method: string | null;
 
+  /**
+   * The property that was changed, if any
+   */
   property: string | null;
 
+  /**
+   * The new value of the property, or null if the property was cleared
+   */
   value: string | null;
 
+  /**
+   * The prior version number to restore to
+   */
   restoreVersion: number | null;
 };

--- a/src/models/ProjectVersionDto.ts
+++ b/src/models/ProjectVersionDto.ts
@@ -13,6 +13,11 @@
 
 import { ProjectVersionChangeDataDto } from "../index.js";
 
+/**
+ * A ProjectVersion is a snapshot of a Project at a specific moment in time.  Information on
+ * the ProjectVersion record keeps track of the unique identity of this version, plus the name
+ * and details of the user who created this version, and the changes that were made.
+ */
 export type ProjectVersionDto = {
 
   /**

--- a/src/models/ResourcesCreateDto.ts
+++ b/src/models/ResourcesCreateDto.ts
@@ -14,6 +14,9 @@
 import { ResourceCreateDto } from "../index.js";
 
 /**
+ * The ResourcesCreate object allows you to create multiple Users with a single API call.
+ * In ProjectManager.com, a User is a special class of Resource.
+ *
  * A Resource represents a person, material, or tool that is used within your Projects.
  * When you attach a Resources to more than one Task, the software will schedule the usage
  * of your Resource so that it is not allocated to more than one Task at the same time.
@@ -23,9 +26,13 @@ import { ResourceCreateDto } from "../index.js";
 export type ResourcesCreateDto = {
 
   /**
-   * When creating a user they will also be added to the projectIds specified. If null or empty the user will be invited but no access will be given to any projects.
+   * When creating a user they will also be added to the projectIds specified. If null or empty the user will be
+   * invited but no access will be given to any projects.
    */
   projectIds: string[] | null;
 
+  /**
+   * A list of Users to create
+   */
   users: ResourceCreateDto[] | null;
 };

--- a/src/models/ResourcesDto.ts
+++ b/src/models/ResourcesDto.ts
@@ -15,6 +15,8 @@ import { ResourceDto } from "../index.js";
 import { UserError } from "../index.js";
 
 /**
+ * The Resources object represents the results of a bulk Resource creation API call.
+ *
  * A Resource represents a person, material, or tool that is used within your Projects.
  * When you attach a Resources to more than one Task, the software will schedule the usage
  * of your Resource so that it is not allocated to more than one Task at the same time.
@@ -23,7 +25,13 @@ import { UserError } from "../index.js";
  */
 export type ResourcesDto = {
 
+  /**
+   * The list of the Resources created by this API call.
+   */
   resources: ResourceDto[] | null;
 
+  /**
+   * The list of errors that occurred for Resources that could not be created.
+   */
   errors: UserError[] | null;
 };

--- a/src/models/TaskDto.ts
+++ b/src/models/TaskDto.ts
@@ -173,6 +173,22 @@ export type TaskDto = {
   isSummary: boolean;
 
   /**
+   * Unlocked tasks can be adjusted by changes to their dependencies, resource leveling, or other factors.
+   *
+   * All tasks are unlocked by default.
+   *
+   * If a task is set to `IsLocked` = `true`, the dates and assigned resources are locked for this task and will not
+   * be automatically changed by any process.
+   */
+  isLocked: boolean;
+
+  /**
+   * True if this task is a milestone.  Milestones represent a specific point in time for the project.  When a
+   * milestone is locked, it represents a fixed time within the project that can be used to relate to other tasks.
+   */
+  isMilestone: boolean;
+
+  /**
    * Return the priority of a task
    */
   priorityId: number | null;

--- a/src/models/TimesheetFileDto.ts
+++ b/src/models/TimesheetFileDto.ts
@@ -12,6 +12,9 @@
  */
 
 
+/**
+ * Represents information about a file attached to a Timesheet.
+ */
 export type TimesheetFileDto = {
 
   /**

--- a/src/models/UserError.ts
+++ b/src/models/UserError.ts
@@ -12,11 +12,24 @@
  */
 
 
+/**
+ * Represents an individual error for a specific Resource that could not be created in the context
+ * of a bulk Resource creation API call.
+ */
 export type UserError = {
 
+  /**
+   * The email of the Resource that could not be created
+   */
   email: string | null;
 
+  /**
+   * A description of the reason this Resource could not be created
+   */
   reason: string | null;
 
+  /**
+   * A status code explaining the category of reason this Resource could not be created
+   */
   statusCode: string;
 };

--- a/src/models/WorkSpaceDto.ts
+++ b/src/models/WorkSpaceDto.ts
@@ -35,11 +35,6 @@ export type WorkSpaceDto = {
   customProductDomain: string | null;
 
   /**
-   * TODO - What is this value?
-   */
-  customerId: string | null;
-
-  /**
    * This value is set to true if the user who retrieves this Workspace object via an API call is
    * the owner of this Workspace.
    */


### PR DESCRIPTION
# Patch notes for 119.0.4625

These patch notes summarize the changes from version 117.0.4438.

Added 5 new APIs:
* ProjectVersion.RetrieveProjectVersions (GET /api/data/projects/{projectId}/versions)
* ProjectVersion.DownloadMSProjectXml (GET /api/data/projects/{projectChangeId}/version/download)
* ProjectVersion.RestoreProjectVersion (POST /api/data/projects/{projectId}/version/{version}/restore)
* ProjectVersion.CopyProjectVersion (POST /api/data/projects/{projectId}/version/{version}/copy)
* Risk.CreateRiskExport (POST /api/data/projects/{projectId}/risks/export)

Renamed 1 old APIs:
* Renamed 'TaskMetadata.GetTasksByProjectIDAndForeignKeyID' to 'TaskMetadata.TaskMetadataSearch'

Changes to data models:
* TaskDto: Added new field `isLocked`
* TaskDto: Added new field `isMilestone`