### PR TITLE
fix: split package keyword string into entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "author": "ProjectManager.com support@projectmanager.com ()",
     "keywords": [
-        "projectmanager project management task tracking projects tasks"
+        "projectmanager", "project management", "task tracking", "projects", "tasks"
     ],
     "homepage": "",
     "dependencies": {


### PR DESCRIPTION
Stumbled onto this guy randomly and noticed the keywords in npm were all lumped together; quick fix to split them up to help your package get more visibility.

https://www.npmjs.com/package/projectmanager-sdk