### PR TITLE
Fix npm audit for brace-expansion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: npm install
         run: npm install
-      - name: npm audit
-        run: npm audit
+# If there's a minor vulnerability issue in package-lock.json here, let's try autofixing it rather than failing to ship
+      - name: npm audit (with fix)
+        run: npm audit fix
       - name: ESLint
         run: npm run lint
       - name: npm compile

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -37,7 +37,11 @@ jobs:
             SdkGenerator get-patch-notes -p ./sdk-config.json
             echo EOF
           } >> $GITHUB_OUTPUT
-          
+        
+# Running npm audit fix here will address minor issues with package-lock.json and ensure they are committed to main
+      - name: npm audit (with fix)
+        run: npm audit fix
+
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "projectmanager-sdk",
-    "version": "129.0.113",
+    "version": "135.0.134",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "projectmanager-sdk",
-            "version": "129.0.113",
+            "version": "135.0.134",
             "license": "MIT",
             "dependencies": {
                 "axios": "^1.6.2",
@@ -911,9 +911,9 @@
             "dev": true
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",


### PR DESCRIPTION
In experience, we often find minor dependency issues each time we ship a release.  To make this easier to fix, let's automatically run `npm audit fix` as part of the update and publish processes.  A major change will still need hand review, but this should catch anything obvious.